### PR TITLE
fix: correct Python modulo emulation for negative denominator

### DIFF
--- a/myers.go
+++ b/myers.go
@@ -17,9 +17,9 @@ type Op struct {
 	Elem   interface{} // Actual value to be inserted or deleted
 }
 
-//  Returns a minimal list of differences between 2 lists e and f
-//  requring O(min(len(e),len(f))) space and O(min(len(e),len(f)) * D)
-//  worst-case execution time where D is the number of differences.
+// Returns a minimal list of differences between 2 lists e and f
+// requiring O(min(len(e),len(f))) space and O(min(len(e),len(f)) * D)
+// worst-case execution time where D is the number of differences.
 func Diff(e, f []interface{}, equals func(interface{}, interface{}) bool) []Op {
 	return diffInternal(e, f, equals, 0, 0)
 }
@@ -34,7 +34,7 @@ func diffInternal(e, f []interface{}, equals func(interface{}, interface{}) bool
 		g := make([]int, Z)
 		p := make([]int, Z)
 
-		hMax := ((L/2 + toInt(L%2 != 0)) + 1)
+		hMax := L/2 + L%2 + 1
 		for h := 0; h < hMax; h++ {
 			for r := 0; r < 2; r++ {
 				var c, d []int
@@ -54,10 +54,10 @@ func diffInternal(e, f []interface{}, equals func(interface{}, interface{}) bool
 				kMax := h - 2*max(0, h-N) + 1
 				for k := kMin; k < kMax; k += 2 {
 					var a int
-					if k == -h || k != h && c[absmod((k-1), Z)] < c[absmod((k+1), Z)] {
-						a = c[absmod((k+1), Z)]
+					if k == -h || k != h && c[pyMod((k-1), Z)] < c[pyMod((k+1), Z)] {
+						a = c[pyMod((k+1), Z)]
 					} else {
-						a = c[absmod((k-1), Z)] + 1
+						a = c[pyMod((k-1), Z)] + 1
 					}
 					b := a - k
 					s, t := a, b
@@ -65,9 +65,9 @@ func diffInternal(e, f []interface{}, equals func(interface{}, interface{}) bool
 					for a < N && b < M && equals(e[(1-o)*N+m*a+(o-1)], f[(1-o)*M+m*b+(o-1)]) {
 						a, b = a+1, b+1
 					}
-					c[absmod(k, Z)] = a
+					c[pyMod(k, Z)] = a
 					z := -(k - w)
-					if absmod(L, 2) == o && z >= -(h-o) && z <= h-o && c[absmod(k, Z)]+d[absmod(z, Z)] >= N {
+					if pyMod(L, 2) == o && z >= -(h-o) && z <= h-o && c[pyMod(k, Z)]+d[pyMod(z, Z)] >= N {
 						var D, x, y, u, v int
 						if o == 1 {
 							D = 2*h - 1
@@ -127,29 +127,19 @@ func min(x, y int) int {
 	}
 }
 
-func toInt(b bool) int {
-	if b {
-		return 1
-	} else {
-		return 0
-	}
-}
-
 /**
  * The remainder op in python always matches the sign of the _denominator_
+ * e.g -1%3 = 2.
  * In golang it matches the sign of the numerator.
  * See https://en.wikipedia.org/wiki/Modulo_operation#Variants_of_the_definition
+ * Since we always have a positive denominator here, we can emulate the
+ * pyMod x%y as (x+y) % y
  */
-func abs(x int) int {
-	if x < 0 {
-		return -x
-	} else {
-		return x
-	}
+func pyMod(x, y int) int {
+	return (x + y) % y
 }
-func absmod(x, y int) int {
-	return abs(x % y)
-}
+
+// Let us map element in same way as in
 
 // Convenient wrapper for string lists
 func DiffStr(e, f []string) []Op {

--- a/myers_test.go
+++ b/myers_test.go
@@ -12,6 +12,9 @@ type TestCase struct {
 }
 
 func TestDiff(t *t.T) {
+	A := "A"
+	B := "B"
+	C := "C"
 	testCases := []TestCase{
 		{[]string{}, []string{}, []Op{}},
 		{[]string{}, []string{"foo"}, []Op{{OpInsert, 0, 0, "foo"}}},
@@ -20,6 +23,11 @@ func TestDiff(t *t.T) {
 		{[]string{"baz"}, []string{"foo", "baz"}, []Op{{OpInsert, 0, 0, "foo"}}},
 		{[]string{"bar", "baz"}, []string{"foo", "baz"}, []Op{{OpDelete, 0, -1, "bar"}, {OpInsert, 1, 0, "foo"}}},
 		{[]string{"foo", "bar", "baz"}, []string{"foo", "bar"}, []Op{{OpDelete, 2, -1, "baz"}}},
+		{[]string{A, B, C, A, B, B, A}, []string{C, B, A, B, A, C},
+			[]Op{{OpDelete, 0, -1, A}, {OpInsert, 1, 0, C}, {OpDelete, 2, -1, C}, {OpDelete, 5, -1, B}, {OpInsert, 7, 5, C}}},
+		{[]string{C, A, B, A, B, A, B, A, B, A, B, A, B, C},
+			[]string{B, A, B, A, B, A, B, A, B, A, B, A, B, A},
+			[]Op{{OpDelete, 0, -1, C}, {OpInsert, 1, 0, B}, {OpDelete, 13, -1, C}, {OpInsert, 14, 13, A}}},
 	}
 	for _, c := range testCases {
 		act := DiffStr(c.l1, c.l2)


### PR DESCRIPTION
Thanks for your translation of this nice algorithm into Go.

However, I discovered that it did not work for more complex cases, while the original Python code did.

fix: replace absmod with pyMod that does correct emulation of Python modulo operator.

The code as it was did not work for more complex cases as the last test case added, while the original Python code did.

Removed unnecessary code including a (mod %2) that was converted to a boolean and back again.